### PR TITLE
Allow specifying different PexSearch types

### DIFF
--- a/pex/lib.py
+++ b/pex/lib.py
@@ -5,7 +5,7 @@ import ctypes.util
 import os
 
 MAJOR_VERSION = 4
-MINOR_VERSION = 0
+MINOR_VERSION = 1
 
 
 class _SafeObject(object):

--- a/pex/lib.py
+++ b/pex/lib.py
@@ -288,6 +288,12 @@ def _load_lib():
     ]
     lib.Pex_CheckSearchRequest_AddLookupID.restype = None
 
+    lib.Pex_CheckSearchRequest_SetType.argtypes = [
+        ctypes.POINTER(_Pex_CheckSearchRequest),
+        ctypes.c_int,
+    ]
+    lib.Pex_CheckSearchRequest_SetType.restype = None
+
     # Pex_CheckSearchResult
     lib.Pex_CheckSearchResult_New.argtypes = []
     lib.Pex_CheckSearchResult_New.restype = ctypes.POINTER(


### PR DESCRIPTION
These include:

* **IdentifyMusic:** return assets that will help identify the music within the media file
* **FindMatches:** return all assets that matched the provided media file

Example usage:

```python
req = pex.PexSearchRequest(fingerprint=ft, type=pex.PexSearchType.FIND_MATCHES)
```