### PR TITLE
Added a function for archiving fingerprints

### DIFF
--- a/pex/lib.py
+++ b/pex/lib.py
@@ -329,6 +329,15 @@ def _load_lib():
     ]
     lib.Pex_Ingest.restype = None
 
+    # Pex_Archive
+    lib.Pex_Archive.argtypes = [
+        ctypes.POINTER(_Pex_Client),
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.POINTER(_Pex_Status),
+    ]
+    lib.Pex_Archive.restype = None
+
     return lib
 
 

--- a/pex/lib.py
+++ b/pex/lib.py
@@ -5,7 +5,7 @@ import ctypes.util
 import os
 
 MAJOR_VERSION = 4
-MINOR_VERSION = 1
+MINOR_VERSION = 3
 
 
 class _SafeObject(object):

--- a/pex/private_search.py
+++ b/pex/private_search.py
@@ -158,3 +158,13 @@ class PrivateSearchClient(_Fingerprinter):
             self._c_client.get(), provided_id.encode(), c_ft.get(), c_status.get()
         )
         Error.check_status(c_status)
+
+    def archive(self, provided_id, ft_types=FingerprintType.ALL):
+        lock = _Pex_Lock.new(_lib)
+
+        c_status = _Pex_Status.new(_lib)
+
+        _lib.Pex_Archive(
+            self._c_client.get(), provided_id.encode(), int(ft_types), c_status.get()
+        )
+        Error.check_status(c_status)

--- a/pex/private_search.py
+++ b/pex/private_search.py
@@ -18,7 +18,7 @@ from pex.lib import (
 )
 from pex.errors import Error
 from pex.client import _ClientType, _init_client
-from pex.fingerprint import _Fingerprinter
+from pex.fingerprint import _Fingerprinter, FingerprintType
 
 
 class PrivateSearchRequest(object):


### PR DESCRIPTION
The users can now call archive("provided-id") to archive ingested fingerprints to a private catalog on the PrivateSearchClient.