### PR TITLE
Added Error.is_retryable and RESOURCE_EXHAUSTED

### DIFF
--- a/pex/lib.py
+++ b/pex/lib.py
@@ -5,7 +5,7 @@ import ctypes.util
 import os
 
 MAJOR_VERSION = 4
-MINOR_VERSION = 4
+MINOR_VERSION = 5
 
 
 class _SafeObject(object):
@@ -183,6 +183,9 @@ def _load_lib():
 
     lib.Pex_Status_GetMessage.argtypes = [ctypes.POINTER(_Pex_Status)]
     lib.Pex_Status_GetMessage.restype = ctypes.c_char_p
+
+    lib.Pex_Status_IsRetryable.argtypes = [ctypes.POINTER(_Pex_Status)]
+    lib.Pex_Status_IsRetryable.restype = ctypes.c_bool
 
     # Pex_Buffer
     lib.Pex_Buffer_New.argtypes = []

--- a/pex/mockserver.py
+++ b/pex/mockserver.py
@@ -5,5 +5,17 @@ from pex.errors import Error
 
 
 def mock_client(client):
-    # We used to have a mock server here, but it is no longer supported.
-    pass
+    """
+    Reinitializes a client so that it talks to the MockServer rather than the
+    AE service.
+
+    :param string client: the client that's going to be reinitialized
+    :raise: :class:`Error` if the connection cannot be established
+            or the provided authentication credentials are invalid.
+    """
+    with (
+        _Pex_Lock.new(_lib) as c_lock,
+        _Pex_Status.new(_lib) as c_status,
+    ):
+        _lib.Pex_Mockserver_InitClient(client._c_client.get(), None, c_status.get())
+        Error.check_status(c_status)


### PR DESCRIPTION
The `Error.is_retryable` will tell the user whether retrying this error might resolve the issue.

`RESOURCE_EXHAUSTED` error will be retruned when a user sends more requests that is allowed by their quota.