### PR TITLE
Fix segfault caused by not closing resources properly

### DIFF
--- a/pex/mockserver.py
+++ b/pex/mockserver.py
@@ -5,17 +5,5 @@ from pex.errors import Error
 
 
 def mock_client(client):
-    """
-    Reinitializes a client so that it talks to the MockServer rather than the
-    AE service.
-
-    :param string client: the client that's going to be reinitialized
-    :raise: :class:`Error` if the connection cannot be established
-            or the provided authentication credentials are invalid.
-    """
-
-    lock = _Pex_Lock.new(_lib)
-
-    c_status = _Pex_Status.new(_lib)
-    _lib.Pex_Mockserver_InitClient(client._c_client.get(), None, c_status.get())
-    Error.check_status(c_status)
+    # We used to have a mock server here, but it is no longer supported.
+    pass

--- a/pex/private_search.py
+++ b/pex/private_search.py
@@ -64,27 +64,26 @@ class PrivateSearchFuture(object):
                 because of network issues.
         :rtype: PrivateSearchResult
         """
+        with (
+            _Pex_Lock.new(_lib) as c_lock,
+            _Pex_Status.new(_lib) as c_status,
+            _Pex_CheckSearchRequest.new(_lib) as c_req,
+            _Pex_CheckSearchResult.new(_lib) as c_res,
+        ):
+            for lookup_id in self._lookup_ids:
+                _lib.Pex_CheckSearchRequest_AddLookupID(
+                    c_req.get(), lookup_id.encode()
+                )
 
-        lock = _Pex_Lock.new(_lib)
-
-        c_status = _Pex_Status.new(_lib)
-        c_req = _Pex_CheckSearchRequest.new(_lib)
-        c_res = _Pex_CheckSearchResult.new(_lib)
-
-        for lookup_id in self._lookup_ids:
-            _lib.Pex_CheckSearchRequest_AddLookupID(
-                c_req.get(), lookup_id.encode()
+            _lib.Pex_CheckSearch(
+                self._raw_c_client, c_req.get(), c_res.get(), c_status.get()
             )
+            Error.check_status(c_status)
 
-        _lib.Pex_CheckSearch(
-            self._raw_c_client, c_req.get(), c_res.get(), c_status.get()
-        )
-        Error.check_status(c_status)
-
-        res = _lib.Pex_CheckSearchResult_GetJSON(c_res.get())
-        j = json.loads(res)
-        j['lookup_ids'] = self._lookup_ids
-        return j
+            res = _lib.Pex_CheckSearchResult_GetJSON(c_res.get())
+            j = json.loads(res)
+            j['lookup_ids'] = self._lookup_ids
+            return j
 
     @property
     def lookup_ids(self):
@@ -156,23 +155,23 @@ class Lister(object):
                 because of network issues.
         :rtype: list
         """
-        lock = _Pex_Lock.new(_lib)
+        with (
+            _Pex_Lock.new(_lib) as c_lock,
+            _Pex_Status.new(_lib) as c_status,
+            _Pex_ListRequest.new(_lib) as c_req,
+            _Pex_ListResult.new(_lib) as c_res,
+        ):
+            _lib.Pex_ListRequest_SetAfter(c_req.get(), self._end_cursor.encode())
+            _lib.Pex_ListRequest_SetLimit(c_req.get(), self._limit)
 
-        c_status = _Pex_Status.new(_lib)
-        c_req = _Pex_ListRequest.new(_lib)
-        c_res = _Pex_ListResult.new(_lib)
+            _lib.Pex_List(self._c_client.get(), c_req.get(), c_res.get(), c_status.get())
+            Error.check_status(c_status)
 
-        _lib.Pex_ListRequest_SetAfter(c_req.get(), self._end_cursor.encode())
-        _lib.Pex_ListRequest_SetLimit(c_req.get(), self._limit)
-
-        _lib.Pex_List(self._c_client.get(), c_req.get(), c_res.get(), c_status.get())
-        Error.check_status(c_status)
-
-        res = _lib.Pex_ListResult_GetJSON(c_res.get())
-        j = json.loads(res)
-        self._end_cursor = j['end_cursor']
-        self._has_next_page = j['has_next_page']
-        return j['entries']
+            res = _lib.Pex_ListResult_GetJSON(c_res.get())
+            j = json.loads(res)
+            self._end_cursor = j['end_cursor']
+            self._has_next_page = j['has_next_page']
+            return j['entries']
 
 
 class PrivateSearchClient(_Fingerprinter):
@@ -191,61 +190,60 @@ class PrivateSearchClient(_Fingerprinter):
                 because of network issues.
         :rtype: PrivateSearchFuture
         """
-
-        lock = _Pex_Lock.new(_lib)
-
-        c_status = _Pex_Status.new(_lib)
-        c_ft = _Pex_Buffer.new(_lib)
-        c_req = _Pex_StartSearchRequest.new(_lib)
-        c_res = _Pex_StartSearchResult.new(_lib)
-
-        _lib.Pex_Buffer_Set(c_ft.get(), req.fingerprint._ft, len(req.fingerprint._ft))
-
-        _lib.Pex_StartSearchRequest_SetFingerprint(
-            c_req.get(), c_ft.get(), c_status.get()
-        )
-        Error.check_status(c_status)
-
-        _lib.Pex_StartSearch(
-            self._c_client.get(), c_req.get(), c_res.get(), c_status.get()
-        )
-        Error.check_status(c_status)
-
-        lookup_ids = list()
-        c_lookup_id_pos = ctypes.c_size_t(0)
-        c_lookup_id = ctypes.c_char_p()
-
-        while _lib.Pex_StartSearchResult_NextLookupID(
-            c_res.get(),
-            ctypes.byref(c_lookup_id_pos),
-            ctypes.byref(c_lookup_id)
+        with (
+            _Pex_Lock.new(_lib) as c_lock,
+            _Pex_Status.new(_lib) as c_status,
+            _Pex_Buffer.new(_lib) as c_ft,
+            _Pex_StartSearchRequest.new(_lib) as c_req,
+            _Pex_StartSearchResult.new(_lib) as c_res,
         ):
-            lookup_ids.append(c_lookup_id.value.decode())
+            _lib.Pex_Buffer_Set(c_ft.get(), req.fingerprint._ft, len(req.fingerprint._ft))
 
-        return PrivateSearchFuture(self._c_client, lookup_ids)
+            _lib.Pex_StartSearchRequest_SetFingerprint(
+                c_req.get(), c_ft.get(), c_status.get()
+            )
+            Error.check_status(c_status)
+
+            _lib.Pex_StartSearch(
+                self._c_client.get(), c_req.get(), c_res.get(), c_status.get()
+            )
+            Error.check_status(c_status)
+
+            lookup_ids = list()
+            c_lookup_id_pos = ctypes.c_size_t(0)
+            c_lookup_id = ctypes.c_char_p()
+
+            while _lib.Pex_StartSearchResult_NextLookupID(
+                c_res.get(),
+                ctypes.byref(c_lookup_id_pos),
+                ctypes.byref(c_lookup_id)
+            ):
+                lookup_ids.append(c_lookup_id.value.decode())
+
+            return PrivateSearchFuture(self._c_client, lookup_ids)
 
     def ingest(self, provided_id, ft):
-        lock = _Pex_Lock.new(_lib)
+        with (
+            _Pex_Lock.new(_lib) as c_lock,
+            _Pex_Status.new(_lib) as c_status,
+            _Pex_Buffer.new(_lib) as c_ft,
+        ):
+            _lib.Pex_Buffer_Set(c_ft.get(), ft._ft, len(ft._ft))
 
-        c_status = _Pex_Status.new(_lib)
-        c_ft = _Pex_Buffer.new(_lib)
-
-        _lib.Pex_Buffer_Set(c_ft.get(), ft._ft, len(ft._ft))
-
-        _lib.Pex_Ingest(
-            self._c_client.get(), provided_id.encode(), c_ft.get(), c_status.get()
-        )
-        Error.check_status(c_status)
+            _lib.Pex_Ingest(
+                self._c_client.get(), provided_id.encode(), c_ft.get(), c_status.get()
+            )
+            Error.check_status(c_status)
 
     def archive(self, provided_id, ft_types=FingerprintType.ALL):
-        lock = _Pex_Lock.new(_lib)
-
-        c_status = _Pex_Status.new(_lib)
-
-        _lib.Pex_Archive(
-            self._c_client.get(), provided_id.encode(), int(ft_types), c_status.get()
-        )
-        Error.check_status(c_status)
+        with (
+            _Pex_Lock.new(_lib) as c_lock,
+            _Pex_Status.new(_lib) as c_status,
+        ):
+            _lib.Pex_Archive(
+                self._c_client.get(), provided_id.encode(), int(ft_types), c_status.get()
+            )
+            Error.check_status(c_status)
 
     def list_entries(self, req):
         """


### PR DESCRIPTION
Using `__del__()` to free resources allocated by C++ is not very reliable, especially if the code raises an exception. Using `with` statements provides a way to clean up resources much more explicitly preventing segfaults from happening.